### PR TITLE
adding Numbers of cells per battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Please remove the `--> *` comments to get a valid `JSON`. Comments are not allow
 
         "NrOfModulesOnline": 0,               --> Number - How many modules are online
         "NrOfModulesOffline": 0,              --> Number - How many modules are offline
+        "NrOfCellsPerBattery: 0,              --> Number - How many celle are in the battery
 
         "NrOfModulesBlockingCharge": 0,       --> Number - How many modules are blocking charge
         "NrOfModulesBlockingDischarge": 0     --> Number - How many modules are blocking discharge

--- a/dbus-mqtt-battery/dbus-mqtt-battery.py
+++ b/dbus-mqtt-battery/dbus-mqtt-battery.py
@@ -177,6 +177,7 @@ battery_dict = {
     "/System/MaxTemperatureCellId": {"value": None, "textformat": _s},
     "/System/MaxCellTemperature": {"value": None, "textformat": _t},
     "/System/MOSTemperature": {"value": None, "textformat": _t},
+    "/System/NrOfCellsPerBattery": {"value": 0, "textformat": _n},
     "/System/NrOfModulesOnline": {"value": 1, "textformat": _n},
     "/System/NrOfModulesOffline": {"value": 0, "textformat": _n},
     "/System/NrOfModulesBlockingCharge": {"value": 0, "textformat": _n},


### PR DESCRIPTION
the information about the number of cells is required for for further processing in dbus-aggregate-batteries.
I'd suggest to put this also in your version of the driver, as it won't harm
Cheers, Kolja